### PR TITLE
Nginx updates for pimcore 6.9

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -71,6 +71,18 @@ web:
           allow: true
         '^/static/(?<resource>.*)$':
           allow: true
+        '^/cache-buster-(?:\d+)/(.*)':
+          passthru: '/$1'
+        '^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$':
+          passthru: '/var/assets$uri'
+    '/var/assets':
+      root: web/var/assets
+      passthru: false
+      scripts: false
+      allow: true
+      rules:
+        \.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$:
+          expires: 2w
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048
@@ -84,6 +96,8 @@ hooks:
 
     # This is needed for the installer in the deploy hook.
     curl -sS https://platform.sh/cli/installer | php
+
+    wkhtmltopdf -V
 
     composer install --no-ansi --no-progress --prefer-dist --no-scripts
   deploy: |

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,10 @@
   "require": {
     "php": ">=7.2",
     "doctrine/orm": "^2.7",
-    "pimcore/pimcore": "~6.7.0",
+    "fpdf/fpdf": "^1.83",
+    "pimcore/pimcore": "~6.9.1",
     "platformsh/config-reader": "^2.3",
-    "wikimedia/composer-merge-plugin": "^1.4"
+    "wikimedia/composer-merge-plugin": "^2.0.1"
   },
   "require-dev": {
     "cache/integration-tests": "^0.16.0",


### PR DESCRIPTION
I'm using pimcore 6.9 on platform.sh

in this version, there is two thing that was breaking my installation.

the js and css are now in a new url that starts with __cache-buster-**random_number**__
the images are now with is own aliases and the files are located in a diferent folder: /var/assets

this PR is what worked on me, so sharing this with you guys.